### PR TITLE
Add action mailer

### DIFF
--- a/app/mailers/sale_mailer.rb
+++ b/app/mailers/sale_mailer.rb
@@ -1,0 +1,2 @@
+class SaleMailer < ApplicationMailer
+end

--- a/app/mailers/sale_mailer.rb
+++ b/app/mailers/sale_mailer.rb
@@ -1,2 +1,12 @@
+# frozen_string_literal: true
+
 class SaleMailer < ApplicationMailer
+  default from: 'aax.chiri@gmail.com'
+
+  def sale_email
+    @user = params[:user]
+    @sale_data = params[:sale_data]
+    @book = Book.find(@sale_data[:book_id])
+    mail(to: @user.email, subject: "【せるれぽ】#{@book.title}がセールになっています")
+  end
 end

--- a/app/views/sale_mailer/sale_email.html.slim
+++ b/app/views/sale_mailer/sale_email.html.slim
@@ -1,0 +1,26 @@
+h1
+  = "#{@book.title}のセール情報です。"
+
+- if @sale_data[:amazon].present?
+  p
+    | Amazon
+  p
+    = "価格： #{@sale_data[:amazon][:price]}"
+  p
+    = link_to '商品ページへ', @sale_data[:amazon][:url]
+
+- if @sale_data[:dmm].present?
+  p
+    | DMMブックス
+  p
+    = "価格： #{@sale_data[:dmm][:price]}"
+  p
+    = link_to '商品ページへ', @sale_data[:dmm][:url]
+
+- if @sale_data[:rakuten].present?
+  p
+    | 楽天BOOKS
+  p
+    = "価格： #{@sale_data[:rakuten][:price]}"
+  p
+    = link_to '商品ページへ', @sale_data[:rakuten][:url]

--- a/app/views/sale_mailer/sale_email.text.slim
+++ b/app/views/sale_mailer/sale_email.text.slim
@@ -1,0 +1,16 @@
+= "#{@book.title}のセール情報です。"
+
+- if @sale_data[:amazon].present?
+  | Amazon
+  = "価格： #{@sale_data[:amazon][:price]}"
+  = link_to '商品ページへ', @sale_data[:amazon][:url]
+
+- if @sale_data[:dmm].present?
+  | DMMブックス
+  = "価格： #{@sale_data[:dmm][:price]}"
+  = link_to '商品ページへ', @sale_data[:dmm][:url]
+
+- if @sale_data[:rakuten].present?
+  | 楽天BOOKS
+  = "価格： #{@sale_data[:rakuten][:price]}"
+  = link_to '商品ページへ', @sale_data[:rakuten][:url]

--- a/spec/mailers/previews/sale_mailer_preview.rb
+++ b/spec/mailers/previews/sale_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/sale_mailer
+class SaleMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/previews/sale_mailer_preview.rb
+++ b/spec/mailers/previews/sale_mailer_preview.rb
@@ -1,4 +1,0 @@
-# Preview all emails at http://localhost:3000/rails/mailers/sale_mailer
-class SaleMailerPreview < ActionMailer::Preview
-
-end

--- a/spec/mailers/sale_mailer_spec.rb
+++ b/spec/mailers/sale_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe SaleMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/sale_mailer_spec.rb
+++ b/spec/mailers/sale_mailer_spec.rb
@@ -3,5 +3,27 @@
 require 'rails_helper'
 
 RSpec.describe SaleMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'sale_email' do
+    let(:user) { create(:alice) }
+    let(:book) { create(:cherry) }
+    let(:sale_data) do
+      { book_id: book.id,
+        amazon:
+          { price: 2926,
+            url: 'https://www.amazon.co.jp/dp/B0734GH91L/' } }
+    end
+    let(:mail) { described_class.with(user: user, sale_data: sale_data).sale_email }
+
+    it 'ユーザーのメールアドレスに送ること' do
+      expect(mail.to).to eq [user.email]
+    end
+
+    it '指定のメールアドレスから送信すること' do
+      expect(mail.from).to eq ['aax.chiri@gmail.com']
+    end
+
+    it '正しい件名で送信すること' do
+      expect(mail.subject).to eq "【せるれぽ】#{book.title}がセールになっています"
+    end
+  end
 end

--- a/spec/mailers/sale_mailer_spec.rb
+++ b/spec/mailers/sale_mailer_spec.rb
@@ -1,4 +1,6 @@
-require "rails_helper"
+# frozen_string_literal: true
+
+require 'rails_helper'
 
 RSpec.describe SaleMailer, type: :mailer do
   pending "add some examples to (or delete) #{__FILE__}"


### PR DESCRIPTION
ref: #6 

## やったこと
- ActionMailerの導入
- セール検知時のメール送信メソッド `sale_email`を実装
- `#sale_email`用のメッセージテンプレートを作成