### PR TITLE
メール通知のトリガーとなる割引率を任意に設定できる機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 
+gem 'active_flag'
 gem 'bulma-rails', '~> 0.9.1'
 gem 'capybara', '>= 3.26'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_flag (1.5.0)
+      activerecord (>= 5)
     activejob (6.1.4.1)
       activesupport (= 6.1.4.1)
       globalid (>= 0.3.6)
@@ -364,6 +366,7 @@ PLATFORMS
   x86_64-darwin-19
 
 DEPENDENCIES
+  active_flag
   bootsnap (>= 1.4.4)
   bulma-rails (~> 0.9.1)
   byebug

--- a/app/assets/stylesheets/_form.scss
+++ b/app/assets/stylesheets/_form.scss
@@ -1,0 +1,5 @@
+.field {
+  .block {
+    margin-bottom: 0.5rem !important;
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,11 @@
 
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:account_update, keys: [:discount_rating])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
 
   validates :uid, presence: true, uniqueness: { scope: :provider }, if: -> { uid.present? }
 
+  flag :discount_rating, %i[even between10_and20 between20_and30 between30_and50 over50]
+
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.email = auth.info.email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
 
   validates :uid, presence: true, uniqueness: { scope: :provider }, if: -> { uid.present? }
 
-  flag :discount_rating, %i[even between10_and20 between20_and30 between30_and50 over50]
+  flag :discount_rating, %i[even over10 over20 over30 over50]
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -6,6 +6,30 @@ section.section.is-medium
   = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'block' }) do |f|
     = render 'devise/shared/error_messages', resource: resource
 
+    .field
+      = f.label :discount_rating, class: 'label'
+      p.block 書籍の金額が設定した割引率分安くなった時にメールで通知します。
+      .block
+        label.radio
+          = f.radio_button :discount_rating, :even, class: 'radio', checked: current_user.discount_rating.even?
+          | 10％以下
+      .block
+        label.radio
+          = f.radio_button :discount_rating, :between10_and20, class: 'radio', checked: current_user.discount_rating.between10_and20?
+          | 11％〜20％
+      .block
+        label.radio
+          = f.radio_button :discount_rating, :between20_and30, class: 'radio', checked: current_user.discount_rating.between20_and30?
+          | 21％〜30％
+      .block
+        label.radio
+          = f.radio_button :discount_rating, :between30_and50, class: 'radio', checked: current_user.discount_rating.between30_and50?
+          | 31％〜50％
+      .block
+        label.radio
+          = f.radio_button :discount_rating, :over50, class: 'radio', checked: current_user.discount_rating.over50?
+          | 50％以上
+
     .field style="width: 327px;"
       = f.label :email, class: 'label'
       = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'input'

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -8,27 +8,26 @@ section.section.is-medium
 
     .field
       = f.label :discount_rating, class: 'label'
-      p.block 書籍の金額が設定した割引率分安くなった時にメールで通知します。
       .block
         label.radio
           = f.radio_button :discount_rating, :even, class: 'radio', checked: current_user.discount_rating.even?
-          | 10％以下
+          | すべて通知する
       .block
         label.radio
-          = f.radio_button :discount_rating, :between10_and20, class: 'radio', checked: current_user.discount_rating.between10_and20?
-          | 11％〜20％
+          = f.radio_button :discount_rating, :over10, class: 'radio', checked: current_user.discount_rating.over10?
+          | 10％以上安ければ通知する
       .block
         label.radio
-          = f.radio_button :discount_rating, :between20_and30, class: 'radio', checked: current_user.discount_rating.between20_and30?
-          | 21％〜30％
+          = f.radio_button :discount_rating, :over20, class: 'radio', checked: current_user.discount_rating.over20?
+          | 20％以上安ければ通知する
       .block
         label.radio
-          = f.radio_button :discount_rating, :between30_and50, class: 'radio', checked: current_user.discount_rating.between30_and50?
-          | 31％〜50％
+          = f.radio_button :discount_rating, :over30, class: 'radio', checked: current_user.discount_rating.over30?
+          | 30％以上安ければ通知する
       .block
         label.radio
           = f.radio_button :discount_rating, :over50, class: 'radio', checked: current_user.discount_rating.over50?
-          | 50％以上
+          | 50％以上安ければ通知する
 
     .field style="width: 327px;"
       = f.label :email, class: 'label'

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -24,6 +24,7 @@ ja:
         unconfirmed_email: 未確認Eメール
         unlock_token: ロック解除用トークン
         updated_at: 更新日
+        discount_rating: 通知する割引率
     models:
       user: ユーザー
   devise:

--- a/db/fixtures/books.yml
+++ b/db/fixtures/books.yml
@@ -1,0 +1,44 @@
+cherry:
+  title: プロを目指す人のためのRuby入門
+  author: 伊藤淳一（プログラミング）
+  image: https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3977/9784774193977.jpg?_ex=120x120
+  url: https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F15209044%2F
+  sales_date: 2017年12月
+  isbn_13: 9784774193977
+  price: 3278
+
+fun_ruby:
+  title: たのしいRuby 第6版
+  author: 高橋 征義/後藤 裕蔵
+  image: https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9844/9784797399844.jpg?_ex=120x120
+  url: https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F15822269%2F
+  sales_date: 2019年03月20日頃
+  isbn_13: 9784797399844
+  price: 2860
+
+perfect_rails:
+  title: パーフェクト Ruby on Rails　【増補改訂版】
+  author: すがわらまさのり／前島真一/橋立友宏／五十嵐邦明
+  image: https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4626/9784297114626.jpg?_ex=120x120
+  url: https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F16352336%2F
+  sales_date: 2020年07月25日頃
+  isbn_13: 9784297114626
+  price: 3828
+
+cho_nyumon:
+  title: ゼロからわかるRuby超入門
+  author: 五十嵐邦明/松岡浩平
+  image: https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1237/9784297101237.jpg?_ex=120x120
+  url: https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F15664673%2F
+  sales_date: 2018年12月
+  isbn_13: 9784297101237
+  price: 2728
+
+genba_rails:
+  title: 現場で使える Ruby on Rails 5速習実践ガイド
+  author: 大場寧子/松本拓也
+  image: https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2227/9784839962227.jpg?_ex=120x120
+  url: https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F15628625%2F
+  sales_date: 2018年10月19日頃
+  isbn_13: 9784839962227
+  price: 3828

--- a/db/fixtures/list_details.yml
+++ b/db/fixtures/list_details.yml
@@ -1,0 +1,99 @@
+list_detail1:
+  list: list1
+  book: cherry
+
+list_detai2:
+  list: list1
+  book: fun_ruby
+
+list_detail3:
+  list: list1
+  book: perfect_rails
+
+list_detail4:
+  list: list1
+  book: cho_nyumon
+
+list_detail5:
+  list: list1
+  book: genba_rails
+
+list_detail6:
+  list: list2
+  book: cherry
+
+list_detai7:
+  list: list2
+  book: fun_ruby
+
+list_detail8:
+  list: list2
+  book: perfect_rails
+
+list_detail9:
+  list: list2
+  book: cho_nyumon
+
+list_detail10:
+  list: list2
+  book: genba_rails
+
+list_detail11:
+  list: list3
+  book: cherry
+
+list_detai12:
+  list: list3
+  book: fun_ruby
+
+list_detail13:
+  list: list3
+  book: perfect_rails
+
+list_detail14:
+  list: list3
+  book: cho_nyumon
+
+list_detail15:
+  list: list3
+  book: genba_rails
+
+list_detail16:
+  list: list4
+  book: cherry
+
+list_detai17:
+  list: list4
+  book: fun_ruby
+
+list_detail18:
+  list: list4
+  book: perfect_rails
+
+list_detail19:
+  list: list4
+  book: cho_nyumon
+
+list_detail20:
+  list: list4
+  book: genba_rails
+
+list_detail21:
+  list: list5
+  book: cherry
+
+list_detai22:
+  list: list5
+  book: fun_ruby
+
+list_detail23:
+  list: list5
+  book: perfect_rails
+
+list_detail24:
+  list: list5
+  book: cho_nyumon
+
+list_detail25:
+  list: list5
+  book: genba_rails

--- a/db/fixtures/lists.yml
+++ b/db/fixtures/lists.yml
@@ -1,0 +1,14 @@
+list1:
+  user: rating_even
+
+list2:
+  user: rating_over10
+
+list3:
+  user: rating_over20
+
+list4:
+  user: rating_over30
+
+list5:
+  user: rating_over50

--- a/db/fixtures/users.yml
+++ b/db/fixtures/users.yml
@@ -1,0 +1,69 @@
+test:
+  email: test@example.com
+  encrypted_password: $2a$12$bV39JWhXWb6LkkzKQHZbjewDM9lADAtxMTq7JR68Ub3dF9mZ2P0ne
+  provider: ''
+  uid: 2b410d44-c2fd-4095-8efe-92405bc79cf1
+  discount_rating: 1
+  confirmed_at: 2021-09-10 09:34:19
+  created_at: 2021-09-10 09:34:19
+  updated_at: 2021-09-10 09:59:46
+
+google_auth:
+  email: google@example.com
+  encrypted_password: $2a$12$bV39JWhXWb6LkkzKQHZbjewDM9lADAtxMTq7JR68Ub3dF9mZ2P0ne
+  provider: google_oauth2
+  uid: 2b410d44-c2fd-4095-8efe-92405bc79cf7
+  discount_rating: 1
+  confirmed_at: 2021-09-10 09:34:19
+  created_at: 2021-09-10 09:34:19
+  updated_at: 2021-09-10 09:59:46
+
+rating_even:
+  email: even@example.com
+  encrypted_password: $2a$12$bV39JWhXWb6LkkzKQHZbjewDM9lADAtxMTq7JR68Ub3dF9mZ2P0ne
+  provider: ''
+  uid: 2b410d44-c2fd-4095-8efe-92405bc79cf2
+  discount_rating: 1
+  confirmed_at: 2021-09-10 09:34:19
+  created_at: 2021-09-10 09:34:19
+  updated_at: 2021-09-10 09:59:46
+
+rating_over10:
+  email: over10@example.com
+  encrypted_password: $2a$12$bV39JWhXWb6LkkzKQHZbjewDM9lADAtxMTq7JR68Ub3dF9mZ2P0ne
+  provider: ''
+  uid: 2b410d44-c2fd-4095-8efe-92405bc79cf3
+  discount_rating: 2
+  confirmed_at: 2021-09-10 09:34:19
+  created_at: 2021-09-10 09:34:19
+  updated_at: 2021-09-10 09:59:46
+
+rating_over20:
+  email: over20@example.com
+  encrypted_password: $2a$12$bV39JWhXWb6LkkzKQHZbjewDM9lADAtxMTq7JR68Ub3dF9mZ2P0ne
+  provider: ''
+  uid: 2b410d44-c2fd-4095-8efe-92405bc79cf4
+  discount_rating: 4
+  confirmed_at: 2021-09-10 09:34:19
+  created_at: 2021-09-10 09:34:19
+  updated_at: 2021-09-10 09:59:46
+
+rating_over30:
+  email: over30@example.com
+  encrypted_password: $2a$12$bV39JWhXWb6LkkzKQHZbjewDM9lADAtxMTq7JR68Ub3dF9mZ2P0ne
+  provider: ''
+  uid: 2b410d44-c2fd-4095-8efe-92405bc79cf5
+  discount_rating: 8
+  confirmed_at: 2021-09-10 09:34:19
+  created_at: 2021-09-10 09:34:19
+  updated_at: 2021-09-10 09:59:46
+
+rating_over50:
+  email: over50@example.com
+  encrypted_password: $2a$12$bV39JWhXWb6LkkzKQHZbjewDM9lADAtxMTq7JR68Ub3dF9mZ2P0ne
+  provider: ''
+  uid: 2b410d44-c2fd-4095-8efe-92405bc79cf6
+  discount_rating: 16
+  confirmed_at: 2021-09-10 09:34:19
+  created_at: 2021-09-10 09:34:19
+  updated_at: 2021-09-10 09:59:46

--- a/db/migrate/20211002092405_add_discount_rating_to_users.rb
+++ b/db/migrate/20211002092405_add_discount_rating_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDiscountRatingToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :discount_rating, :integer, null:false, default: 1, limit: 8
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_10_075410) do
+ActiveRecord::Schema.define(version: 2021_10_02_092405) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2021_09_10_075410) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "provider", default: "", null: false
     t.string "uid", default: "", null: false
+    t.bigint "discount_rating", default: 1, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+
+require 'active_record/fixtures'
+
+ActiveRecord::FixtureSet.create_fixtures 'db/fixtures', %i[
+  users
+  books
+  lists
+  list_details
+]

--- a/lib/mail_sender.rb
+++ b/lib/mail_sender.rb
@@ -3,14 +3,55 @@
 class MailSender
   def self.sale_report(compared_data)
     compared_data.each do |data|
-      next if data[:amazon].nil? && data[:dmm].nil? && data[:rakuten].nil?
+      next if all_data_nil?(data)
 
       details = ListDetail.where(book_id: data[:book_id])
       details.each do |detail|
         user = detail.list.user
-        sale_data = data
-        SaleMailer.with(user: user, sale_data: sale_data).sale_email.deliver_now
+        discount_rating = get_rating(user)
+        book = Book.find(detail.book_id)
+        discounted_price = (book.price * discount_rating).truncate
+
+        data[:amazon] = nil if higher_than_discounted_price?(data[:amazon], discounted_price)
+        data[:dmm] = nil if higher_than_discounted_price?(data[:dmm], discounted_price)
+        data[:rakuten] = nil if higher_than_discounted_price?(data[:rakuten], discounted_price)
+        next if all_data_nil?(data)
+
+        SaleMailer.with(user: user, sale_data: data).sale_email.deliver_now
       end
+    end
+  end
+
+  def self.all_data_nil?(data)
+    if data[:amazon].nil? && data[:dmm].nil? && data[:rakuten].nil?
+      true
+    else
+      false
+    end
+  end
+
+  def self.get_rating(user)
+    case user.discount_rating.to_a
+    when [:even]
+      1
+    when [:over10]
+      0.9
+    when [:over20]
+      0.8
+    when [:over30]
+      0.7
+    when [:over50]
+      0.5
+    else
+      1
+    end
+  end
+
+  def self.higher_than_discounted_price?(price_data, discounted_price)
+    if price_data.present? && (price_data[:price] >= discounted_price)
+      true
+    else
+      false
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     password_confirmation { 'password' }
     confirmed_at { Time.current }
   end
+
   factory :google_oauth, class: 'User' do
     email { 'google@example.com' }
     password { 'password' }
@@ -14,5 +15,45 @@ FactoryBot.define do
     confirmed_at { Time.current }
     uid { '123456789' }
     provider { 'google_oauth2' }
+  end
+
+  factory :rating_even, class: 'User' do
+    email { 'even@example.com' }
+    password { 'password' }
+    password_confirmation { 'password' }
+    confirmed_at { Time.current }
+    discount_rating { :even }
+  end
+
+  factory :rating_over10, class: 'User' do
+    email { 'over10@example.com' }
+    password { 'password' }
+    password_confirmation { 'password' }
+    confirmed_at { Time.current }
+    discount_rating { :over10 }
+  end
+
+  factory :rating_over20, class: 'User' do
+    email { 'over20@example.com' }
+    password { 'password' }
+    password_confirmation { 'password' }
+    confirmed_at { Time.current }
+    discount_rating { :over20 }
+  end
+
+  factory :rating_over30, class: 'User' do
+    email { 'over30@example.com' }
+    password { 'password' }
+    password_confirmation { 'password' }
+    confirmed_at { Time.current }
+    discount_rating { :over30 }
+  end
+
+  factory :rating_over50, class: 'User' do
+    email { 'over50@example.com' }
+    password { 'password' }
+    password_confirmation { 'password' }
+    confirmed_at { Time.current }
+    discount_rating { :over50 }
   end
 end

--- a/spec/lib/mail_sender_spec.rb
+++ b/spec/lib/mail_sender_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../lib/mail_sender'
+
+RSpec.describe MailSender, type: :module do
+  let(:price_data) do
+    {
+      amazon: {
+        price: 1000,
+        url: 'https://amazon.com'
+      },
+      dmm: {
+        price: 2000,
+        url: 'https://books.dmm.com'
+      },
+      rakuten: {
+        price: 3000,
+        url: 'https://books.rakuten.com'
+      }
+    }
+  end
+
+  # TODO: #sale_reportのテストを書く
+
+  describe '#all_data_nil?' do
+    context '全ての属性が存在する場合' do
+      it 'falseが返ること' do
+        expect(described_class).not_to be_all_data_nil(price_data)
+      end
+    end
+
+    context 'いずれか1つの属性が存在しない場合' do
+      it 'falseが返ること' do
+        price_data[:amazon] = nil
+        expect(described_class).not_to be_all_data_nil(price_data)
+      end
+    end
+
+    context 'いずれか2つの属性が存在しない場合' do
+      it 'falseが返ること' do
+        price_data[:amazon] = nil
+        price_data[:dmm] = nil
+        expect(described_class).not_to be_all_data_nil(price_data)
+      end
+    end
+
+    context '全ての属性が存在しない場合' do
+      it 'trueが返ること' do
+        price_data[:amazon] = nil
+        price_data[:dmm] = nil
+        price_data[:rakuten] = nil
+        expect(described_class).to be_all_data_nil(price_data)
+      end
+    end
+  end
+
+  describe '#get_rating' do
+    context 'evenのユーザーの場合' do
+      it '1が返ること' do
+        user = create(:rating_even)
+        expect(described_class.get_rating(user)).to eq 1
+      end
+    end
+
+    context 'over10のユーザーの場合' do
+      it '0.9が返ること' do
+        user = create(:rating_over10)
+        expect(described_class.get_rating(user)).to eq 0.9
+      end
+    end
+
+    context 'over20のユーザーの場合' do
+      it '0.8が返ること' do
+        user = create(:rating_over20)
+        expect(described_class.get_rating(user)).to eq 0.8
+      end
+    end
+
+    context 'over30のユーザーの場合' do
+      it '0.7が返ること' do
+        user = create(:rating_over30)
+        expect(described_class.get_rating(user)).to eq 0.7
+      end
+    end
+
+    context 'over50のユーザーの場合' do
+      it '0.5が返ること' do
+        user = create(:rating_over50)
+        expect(described_class.get_rating(user)).to eq 0.5
+      end
+    end
+  end
+
+  describe '#higher_than_discounted_price?' do
+    let(:discount_price) { 500 }
+
+    context 'データが存在し、割引設定に準じた金額より高い場合' do
+      it 'trueを返すこと' do
+        expect(described_class).to be_higher_than_discounted_price(price_data[:amazon], discount_price)
+      end
+    end
+
+    context 'データが存在し、割引設定に準じた金額より安い場合' do
+      it 'falseを返すこと' do
+        price_data[:amazon][:price] = 400
+        expect(described_class).not_to be_higher_than_discounted_price(price_data[:amazon], discount_price)
+      end
+    end
+
+    context 'データが存在せず、割引設定に準じた金額より高い場合' do
+      it 'falseを返すこと' do
+        price_data[:amazon] = nil
+        expect(described_class).not_to be_higher_than_discounted_price(price_data[:amazon], discount_price)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe '正常系' do
+    it '登録成功' do
+      user = build(:alice)
+      expect(user).to be_valid
+    end
+  end
+
+  describe 'email' do
+    context '空の場合' do
+      it '登録失敗' do
+        user = build(:alice, email: '')
+        user.valid?
+        expect(user.errors['email']).to include('を入力してください')
+      end
+    end
+
+    context '@がない場合' do
+      it '登録失敗' do
+        user = build(:alice, email: 'testexample.com')
+        user.valid?
+        expect(user.errors['email']).to include('は不正な値です')
+      end
+    end
+
+    context '登録済みの場合' do
+      it '登録失敗' do
+        create(:alice)
+        user = build(:alice)
+        user.valid?
+        expect(user.errors['email']).to include('はすでに存在します')
+      end
+    end
+  end
+
+  describe 'discount_rating' do
+    context '空の場合' do
+      it '登録成功' do
+        user = build(:alice, discount_rating: '')
+        expect(user).to be_valid
+      end
+
+      it '1に設定される' do
+        user = create(:alice)
+        expect(user.discount_rating.raw).to eq 1
+      end
+    end
+  end
+
+  describe 'provider, uid' do
+    context '空の場合' do
+      it '登録成功' do
+        user = build(:alice, provider: '', uid: '')
+        expect(user).to be_valid
+      end
+    end
+
+    context 'providerとuidの組み合わせが違う場合' do
+      it '登録成功' do
+        create(:alice, provider: '', uid: '')
+        user = build(:google_oauth)
+        expect(user).to be_valid
+      end
+    end
+
+    context 'providerとuidの組み合わせが同じ場合' do
+      it '登録失敗' do
+        user = create(:google_oauth)
+        other_user = build(:alice, provider: user.provider, uid: user.uid)
+        other_user.valid?
+        expect(other_user.errors['uid']).to include('はすでに存在します')
+      end
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe 'Users', type: :system do
         expect(page).to have_css 'input#user_password'
         expect(page).to have_css 'input#user_password_confirmation'
         expect(page).to have_css 'input#user_current_password'
+        expect(page).to have_css 'input#user_discount_rating_even'
+        expect(page).to have_css 'input#user_discount_rating_over10'
+        expect(page).to have_css 'input#user_discount_rating_over20'
+        expect(page).to have_css 'input#user_discount_rating_over30'
+        expect(page).to have_css 'input#user_discount_rating_over50'
         expect(page).to have_link 'ログアウト', href: destroy_user_session_path
         expect(page).to have_link 'アカウント削除', href: user_registration_path
       end
@@ -37,13 +42,18 @@ RSpec.describe 'Users', type: :system do
     context 'Google認証で登録したユーザーの場合' do
       let(:google) { create(:google_oauth) }
 
-      it 'メールアドレス入力フォーム、ログアウト・削除リンクのみがあること' do
+      it 'メールアドレス入力フォーム、割引率設定、ログアウト・削除リンクのみがあること' do
         login google
         visit edit_user_registration_path
 
         expect(page).to have_css 'input#user_email'
         expect(page).to have_link 'ログアウト', href: destroy_user_session_path
         expect(page).to have_link 'アカウント削除', href: user_registration_path
+        expect(page).to have_css 'input#user_discount_rating_even'
+        expect(page).to have_css 'input#user_discount_rating_over10'
+        expect(page).to have_css 'input#user_discount_rating_over20'
+        expect(page).to have_css 'input#user_discount_rating_over30'
+        expect(page).to have_css 'input#user_discount_rating_over50'
         expect(page).not_to have_css 'input#user_password'
         expect(page).not_to have_css 'input#user_password_confirmation'
         expect(page).not_to have_css 'input#user_current_password'


### PR DESCRIPTION
ref: #85 

## やったこと
- Active Flagで割引率用のカラムを追加した
- アカウント編集ページで任意の割引率を設定できるようにした
- セール通知メール送信時、ユーザーが設定した割引率に応じてメール送信の可否を決める処理を入れた
- seedファイルを整備した