### PR TITLE
Booksモデルのisbn_13をisbn13にリネーム

### DIFF
--- a/app/controllers/api/books_controller.rb
+++ b/app/controllers/api/books_controller.rb
@@ -2,10 +2,10 @@
 
 class API::BooksController < API::BaseController
   def create
-    isbn = params['book']['isbn_13']
+    isbn = params['book']['isbn13']
 
-    if Book.find_by('isbn_13' => isbn).present?
-      book = Book.find_by('isbn_13' => isbn)
+    if Book.find_by(isbn13: isbn).present?
+      book = Book.find_by(isbn13: isbn)
       render status: :ok, json: { bookId: book.id }
       return
     end
@@ -23,6 +23,6 @@ class API::BooksController < API::BaseController
   private
 
   def book_params
-    params.require(:book).permit('isbn_13', :price, :title, :author, :image, :url, :sales_date)
+    params.require(:book).permit(:isbn13, :price, :title, :author, :image, :url, :sales_date)
   end
 end

--- a/app/controllers/api/list_details/id_controller.rb
+++ b/app/controllers/api/list_details/id_controller.rb
@@ -2,7 +2,7 @@
 
 class API::ListDetails::IdController < API::BaseController
   def index
-    book = Book.find_by('isbn_13' => params['isbn'])
+    book = Book.find_by(isbn13: params['isbn'])
     list = current_user.list
     list_detail = ListDetail.find_by(list_id: list&.id, book_id: book&.id)
 

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -2,7 +2,7 @@
 
 module BooksHelper
   def registered?(isbn, user)
-    book = Book.find_by('isbn_13' => isbn)
+    book = Book.find_by(isbn13: isbn)
     list = user.list
     list_detail = ListDetail.find_by(list_id: list&.id, book_id: book&.id)
     list_detail.present?

--- a/app/javascript/searched_book.vue
+++ b/app/javascript/searched_book.vue
@@ -116,7 +116,7 @@ export default {
         },
         body: JSON.stringify({
           book: {
-            isbn_13: this.book.isbn,
+            isbn13: this.book.isbn,
             price: this.book.itemPrice,
             title: this.book.title,
             author: this.book.author,

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -4,7 +4,7 @@ class Book < ApplicationRecord
   has_many :list_details, dependent: :destroy
   has_many :lists, through: :list_details
 
-  validates 'isbn_13', presence: true, length: { is: 13 }
+  validates :isbn13, presence: true, length: { is: 13 }
   validates :price, presence: true, numericality: { only_integer: true }
   validates :title, presence: true
   validates :author, presence: true

--- a/db/fixtures/books.yml
+++ b/db/fixtures/books.yml
@@ -4,7 +4,7 @@ cherry:
   image: https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3977/9784774193977.jpg?_ex=120x120
   url: https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F15209044%2F
   sales_date: 2017年12月
-  isbn_13: 9784774193977
+  isbn13: 9784774193977
   price: 3278
 
 fun_ruby:
@@ -13,7 +13,7 @@ fun_ruby:
   image: https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9844/9784797399844.jpg?_ex=120x120
   url: https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F15822269%2F
   sales_date: 2019年03月20日頃
-  isbn_13: 9784797399844
+  isbn13: 9784797399844
   price: 2860
 
 perfect_rails:
@@ -22,7 +22,7 @@ perfect_rails:
   image: https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4626/9784297114626.jpg?_ex=120x120
   url: https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F16352336%2F
   sales_date: 2020年07月25日頃
-  isbn_13: 9784297114626
+  isbn13: 9784297114626
   price: 3828
 
 cho_nyumon:
@@ -31,7 +31,7 @@ cho_nyumon:
   image: https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1237/9784297101237.jpg?_ex=120x120
   url: https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F15664673%2F
   sales_date: 2018年12月
-  isbn_13: 9784297101237
+  isbn13: 9784297101237
   price: 2728
 
 genba_rails:
@@ -40,5 +40,5 @@ genba_rails:
   image: https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2227/9784839962227.jpg?_ex=120x120
   url: https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F15628625%2F
   sales_date: 2018年10月19日頃
-  isbn_13: 9784839962227
+  isbn13: 9784839962227
   price: 3828

--- a/db/migrate/20211103043039_rename_isbn_13_column_to_isbn13.rb
+++ b/db/migrate/20211103043039_rename_isbn_13_column_to_isbn13.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class RenameIsbn13ColumnToIsbn13 < ActiveRecord::Migration[6.1]
-  def change; end
+  def change
+    rename_column :books, :isbn_13, :isbn13
+  end
 end

--- a/db/migrate/20211103043039_rename_isbn_13_column_to_isbn13.rb
+++ b/db/migrate/20211103043039_rename_isbn_13_column_to_isbn13.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class RenameIsbn13ColumnToIsbn13 < ActiveRecord::Migration[6.1]
+  def change; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_02_092405) do
+ActiveRecord::Schema.define(version: 2021_11_03_043039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "books", force: :cascade do |t|
-    t.string "isbn_13"
+    t.string "isbn13"
     t.integer "price"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/lib/comparer.rb
+++ b/lib/comparer.rb
@@ -16,9 +16,9 @@ module Comparer
         dmm = DmmCrawler.new
         rakuten = RakutenCrawler.new
         begin
-          amazon.run(book.isbn_13)
+          amazon.run(book.isbn13)
           dmm.run(book.title)
-          rakuten.run(book.isbn_13)
+          rakuten.run(book.isbn13)
         rescue Capybara::ElementNotFound
           logger << "Capybara::ElementNotFound\n"
         end

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     image { 'https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3977/9784774193977.jpg?_ex=120x120' }
     url { 'https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F15209044%2F' }
     sales_date { '2017年12月' }
-    isbn_13 { '9784774193977' }
+    isbn13 { '9784774193977' }
     price { 3278 }
   end
 
@@ -17,7 +17,7 @@ FactoryBot.define do
     image { 'https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9844/9784797399844.jpg?_ex=120x120' }
     url { 'https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F15822269%2F' }
     sales_date { '2019年03月20日頃' }
-    isbn_13 { '9784797399844' }
+    isbn13 { '9784797399844' }
     price { 2860 }
   end
 
@@ -27,7 +27,7 @@ FactoryBot.define do
     image { 'https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4626/9784297114626.jpg?_ex=120x120' }
     url { 'https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F16352336%2F' }
     sales_date { '2020年07月25日頃' }
-    isbn_13 { '9784297114626' }
+    isbn13 { '9784297114626' }
     price { 3828 }
   end
 
@@ -37,7 +37,7 @@ FactoryBot.define do
     image { 'https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1237/9784297101237.jpg?_ex=120x120' }
     url { 'https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F15664673%2F' }
     sales_date { '2018年12月' }
-    isbn_13 { '9784297101237' }
+    isbn13 { '9784297101237' }
     price { 2728 }
   end
 
@@ -47,7 +47,7 @@ FactoryBot.define do
     image { 'https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2227/9784839962227.jpg?_ex=120x120' }
     url { 'https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F15628625%2F' }
     sales_date { '2018年10月19日頃' }
-    isbn_13 { '9784839962227' }
+    isbn13 { '9784839962227' }
     price { 3828 }
   end
 end

--- a/spec/helpers/books_helper_spec.rb
+++ b/spec/helpers/books_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BooksHelper, type: :helper do
     context 'ListDetailに登録済みの書籍の場合' do
       it 'trueが返る' do
         list_detail = create(:list_detail_one)
-        isbn = list_detail.book.isbn_13
+        isbn = list_detail.book.isbn13
         user = list_detail.list.user
         expect(helper).to be_registered(isbn, user)
       end
@@ -15,7 +15,7 @@ RSpec.describe BooksHelper, type: :helper do
 
     context 'ListDetailに登録されていない書籍の場合' do
       it 'falseが返る' do
-        isbn = create(:perfect_rails).isbn_13
+        isbn = create(:perfect_rails).isbn13
         user = create(:list).user
         expect(helper).not_to be_registered(isbn, user)
       end
@@ -23,7 +23,7 @@ RSpec.describe BooksHelper, type: :helper do
 
     context 'リスト未作成のユーザーの場合' do
       it 'falseが返る' do
-        isbn = create(:perfect_rails).isbn_13
+        isbn = create(:perfect_rails).isbn13
         user = create(:alice)
         expect(helper).not_to be_registered(isbn, user)
       end
@@ -31,7 +31,7 @@ RSpec.describe BooksHelper, type: :helper do
 
     context '書籍情報が登録されていない場合' do
       it 'falseが返る' do
-        isbn = build(:perfect_rails).isbn_13
+        isbn = build(:perfect_rails).isbn13
         user = create(:alice)
         expect(helper).not_to be_registered(isbn, user)
       end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -13,25 +13,25 @@ RSpec.describe Book, type: :model do
   describe 'ISBN' do
     context '空の場合' do
       it '登録失敗' do
-        book = build(:cherry, 'isbn_13' => '')
+        book = build(:cherry, isbn13: '')
         book.valid?
-        expect(book.errors['isbn_13']).to include('を入力してください')
+        expect(book.errors[:isbn13]).to include('を入力してください')
       end
     end
 
     context '12桁の場合' do
       it '登録失敗' do
-        book = build(:cherry, 'isbn_13' => '978123456789')
+        book = build(:cherry, isbn13: '978123456789')
         book.valid?
-        expect(book.errors['isbn_13']).to include('は13文字で入力してください')
+        expect(book.errors[:isbn13]).to include('は13文字で入力してください')
       end
     end
 
     context '14桁の場合' do
       it '登録失敗' do
-        book = build(:cherry, 'isbn_13' => '97812345678901')
+        book = build(:cherry, isbn13: '97812345678901')
         book.valid?
-        expect(book.errors['isbn_13']).to include('は13文字で入力してください')
+        expect(book.errors[:isbn13]).to include('は13文字で入力してください')
       end
     end
   end

--- a/spec/requests/api/list_details/id_spec.rb
+++ b/spec/requests/api/list_details/id_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe 'Api::ListDetails::Id', type: :request do
       context '登録済みの書籍の場合' do
         it '200が返ること' do
           sign_in user
-          get api_list_details_id_index_path({ isbn: book.isbn_13 })
+          get api_list_details_id_index_path({ isbn: book.isbn13 })
           expect(response).to have_http_status(:ok)
         end
 
         it 'リスト詳細IDが返ること' do
           sign_in user
-          get api_list_details_id_index_path({ isbn: book.isbn_13 })
+          get api_list_details_id_index_path({ isbn: book.isbn13 })
           expect(JSON.parse(response.body)['listDetailId']).to eq list_detail.id
         end
       end
@@ -28,13 +28,13 @@ RSpec.describe 'Api::ListDetails::Id', type: :request do
       context '登録済みでない場合' do
         it '422が返ること' do
           sign_in user
-          get api_list_details_id_index_path({ isbn: other_book.isbn_13 })
+          get api_list_details_id_index_path({ isbn: other_book.isbn13 })
           expect(response).to have_http_status(:unprocessable_entity)
         end
 
         it 'リスト詳細IDはnilであること' do
           sign_in user
-          get api_list_details_id_index_path({ isbn: other_book.isbn_13 })
+          get api_list_details_id_index_path({ isbn: other_book.isbn13 })
           expect(JSON.parse(response.body)['listDetailId']).to eq nil
         end
       end
@@ -42,7 +42,7 @@ RSpec.describe 'Api::ListDetails::Id', type: :request do
 
     context '未ログインの場合' do
       it '401が返ること' do
-        get api_list_details_id_index_path({ isbn: book.isbn_13 })
+        get api_list_details_id_index_path({ isbn: book.isbn13 })
         expect(response).to have_http_status(:unauthorized)
       end
     end

--- a/spec/system/amazon_crawler_spec.rb
+++ b/spec/system/amazon_crawler_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'AmazonCrawler', type: :system do
     let(:book) { build(:perfect_rails) }
 
     it '金額は数値、ASINは10桁の文字列が返ってくること' do
-      crawler.run(book.isbn_13)
+      crawler.run(book.isbn13)
       expect(crawler.kindle_price).to be_integer
       expect(crawler.paper_price).to be_integer
       expect(crawler.asin.size).to eq 10

--- a/spec/system/rakuten_crawler_spec.rb
+++ b/spec/system/rakuten_crawler_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'RakutenCrawler', type: :system do
     let(:book) { build(:perfect_rails) }
 
     it '全ての金額が数値で返ってくること' do
-      crawler.run(book.isbn_13)
+      crawler.run(book.isbn13)
       expect(crawler.single_price).to be_integer
       expect(crawler.e_book_price).to be_integer
       expect(crawler.paper_book_price).to be_integer


### PR DESCRIPTION
## なぜリネームしたか
- `isbn_13`だとシンボル記法を使ったときにRubocopに引っかかってしまう
- かと言って文字列だとアクセス速度に影響が出る

これらを解消するために、リネームした上でシンボル記法に書き換えた。