### PR TITLE
各コントローラーの処理を修正

### DIFF
--- a/app/controllers/api/books_controller.rb
+++ b/app/controllers/api/books_controller.rb
@@ -2,21 +2,18 @@
 
 class API::BooksController < API::BaseController
   def create
-    isbn = params['book']['isbn13']
-    book = Book.find_by(isbn13: isbn)
+    book = Book.create_with(book_params).find_or_initialize_by(isbn13: params['book']['isbn13'])
 
-    if book.present?
-      render status: :ok, json: { bookId: book.id }
-      return
-    end
-
-    new_book = Book.new(book_params)
-    if new_book.save
-      render status: :created,
-             json: { bookId: new_book.id }
+    if book.new_record?
+      if book.save
+        render status: :created,
+               json: { bookId: book.id }
+      else
+        render status: :unprocessable_entity,
+               json: { errorMessage: '登録に失敗しました。' }
+      end
     else
-      render status: :unprocessable_entity,
-             json: { errorMessage: '登録に失敗しました。' }
+      render status: :ok, json: { bookId: book.id }
     end
   end
 

--- a/app/controllers/api/books_controller.rb
+++ b/app/controllers/api/books_controller.rb
@@ -3,17 +3,17 @@
 class API::BooksController < API::BaseController
   def create
     isbn = params['book']['isbn13']
+    book = Book.find_by(isbn13: isbn)
 
-    if Book.find_by(isbn13: isbn).present?
-      book = Book.find_by(isbn13: isbn)
+    if book.present?
       render status: :ok, json: { bookId: book.id }
       return
     end
 
-    book = Book.new(book_params)
-    if book.save
+    new_book = Book.new(book_params)
+    if new_book.save
       render status: :created,
-             json: { bookId: book.id }
+             json: { bookId: new_book.id }
     else
       render status: :unprocessable_entity,
              json: { errorMessage: '登録に失敗しました。' }

--- a/app/controllers/api/list_details_controller.rb
+++ b/app/controllers/api/list_details_controller.rb
@@ -2,9 +2,7 @@
 
 class API::ListDetailsController < API::BaseController
   def create
-    list_detail = params['list_detail']
-
-    if ListDetail.find_by(list_id: list_detail['list_id'], book_id: list_detail['book_id']).present?
+    if registered?
       render status: :bad_request, json: { errorMessage: 'すでに登録済みです。' }
       return
     end
@@ -35,5 +33,10 @@ class API::ListDetailsController < API::BaseController
 
   def list_detail_params
     params.require(:list_detail).permit(:list_id, :book_id)
+  end
+
+  def registered?
+    list_detail = params['list_detail']
+    ListDetail.find_by(list_id: list_detail['list_id'], book_id: list_detail['book_id']).present?
   end
 end

--- a/app/controllers/api/list_details_controller.rb
+++ b/app/controllers/api/list_details_controller.rb
@@ -2,18 +2,20 @@
 
 class API::ListDetailsController < API::BaseController
   def create
-    if registered?
-      render status: :bad_request, json: { errorMessage: 'すでに登録済みです。' }
-      return
-    end
+    list_detail = params['list_detail']
+    new_detail = ListDetail.create_with(list_detail_params)
+                           .find_or_initialize_by(list_id: list_detail['list_id'], book_id: list_detail['book_id'])
 
-    list_detail = ListDetail.new(list_detail_params)
-    if list_detail.save
-      render status: :created,
-             json: { message: 'リストに追加しました！' }
+    if new_detail.new_record?
+      if new_detail.save
+        render status: :created,
+               json: { message: 'リストに追加しました！' }
+      else
+        render status: :unprocessable_entity,
+               json: { errorMessage: new_detail.errors.full_messages }
+      end
     else
-      render status: :unprocessable_entity,
-             json: { errorMessage: list_detail.errors.full_messages }
+      render status: :bad_request, json: { errorMessage: 'すでに登録済みです。' }
     end
   end
 
@@ -33,10 +35,5 @@ class API::ListDetailsController < API::BaseController
 
   def list_detail_params
     params.require(:list_detail).permit(:list_id, :book_id)
-  end
-
-  def registered?
-    list_detail = params['list_detail']
-    ListDetail.find_by(list_id: list_detail['list_id'], book_id: list_detail['book_id']).present?
   end
 end

--- a/app/controllers/api/users/lists_controller.rb
+++ b/app/controllers/api/users/lists_controller.rb
@@ -7,17 +7,16 @@ class API::Users::ListsController < API::BaseController
   end
 
   def create
-    if current_user.list.present?
-      list = current_user.list
-      render status: :ok, json: { listId: list.id }
-      return
-    end
+    list = List.create_with(list_params).find_or_initialize_by(user: current_user)
 
-    list = List.new(list_params)
-    if list.save
-      render status: :created, json: { listId: list.id }
+    if list.new_record?
+      if list.save
+        render status: :created, json: { listId: list.id }
+      else
+        render status: :unprocessable_entity, json: { errorMessage: '登録に失敗しました。' }
+      end
     else
-      render status: :unprocessable_entity, json: { errorMessage: '登録に失敗しました。' }
+      render status: :ok, json: { listId: list.id }
     end
   end
 

--- a/app/controllers/api/users/lists_controller.rb
+++ b/app/controllers/api/users/lists_controller.rb
@@ -3,14 +3,7 @@
 class API::Users::ListsController < API::BaseController
   def show
     @list_id = params[:id]
-    @books = ListDetail.where(list_id: @list_id).map do |detail|
-      {
-        list_detail_id: detail.id,
-        book: detail.book
-      }
-    end
-
-    render status: :ok, json: { books: @books }
+    @list_details = ListDetail.where(list_id: @list_id)
   end
 
   def create

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -7,12 +7,7 @@ class BooksController < ApplicationController
       @page_num = (params[:page] || 1).to_i
       count_per_page = 20
 
-      url = "https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404?format=json&hits=#{count_per_page}&affiliateId=#{Rails.application.credentials.rakuten[:af_id]}&applicationId=#{Rails.application.credentials.rakuten[:app_id]}&page=#{@page_num}"
-      url += /^978[0-9]{10}/.match?(@query) ? "&isbn=#{@query}" : "&title=#{@query}"
-
-      client = HTTPClient.new
-      request = client.get(url)
-      response = JSON.parse(request.body)
+      response = RakutenBooksSearcher.new(@query, @page_num, count_per_page).run
 
       @max_page_num = response['pageCount']
       @total_num = response['count']

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
 module BooksHelper
-  def registered?(isbn, user)
-    book = Book.find_by(isbn13: isbn)
-    list = user.list
-    list_detail = ListDetail.find_by(list_id: list&.id, book_id: book&.id)
-    list_detail.present?
-  end
-
   def format_price(price)
     price = price.to_i
     return '情報なし' if price.zero?

--- a/app/javascript/searched_book.vue
+++ b/app/javascript/searched_book.vue
@@ -179,7 +179,6 @@ export default {
         })
         .then((json) => {
           if (json.listDetailId) {
-            console.log(json)
             this.registeredListDetail = true
           }
         })

--- a/app/models/rakuten_books_searcher.rb
+++ b/app/models/rakuten_books_searcher.rb
@@ -2,8 +2,15 @@
 
 class RakutenBooksSearcher
   def initialize(query, page_num, count_per_page)
-    @url = "https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404?format=json&hits=#{count_per_page}&affiliateId=#{Rails.application.credentials.rakuten[:af_id]}&applicationId=#{Rails.application.credentials.rakuten[:app_id]}&page=#{page_num}"
-    @url += /^978[0-9]{10}/.match?(query) ? "&isbn=#{query}" : "&title=#{query}"
+    params = {
+      format: :json,
+      hits: count_per_page,
+      affiliateId: Rails.application.credentials.rakuten[:af_id],
+      applicationId: Rails.application.credentials.rakuten[:app_id],
+      page: page_num,
+      (/^978[0-9]{10}/.match?(query) ? :isbn : :title) => query
+    }.to_query
+    @url = "https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404?#{params}"
   end
 
   def run

--- a/app/models/rakuten_books_searcher.rb
+++ b/app/models/rakuten_books_searcher.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RakutenBooksSearcher
+  def initialize(query, page_num, count_per_page)
+    @url = "https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404?format=json&hits=#{count_per_page}&affiliateId=#{Rails.application.credentials.rakuten[:af_id]}&applicationId=#{Rails.application.credentials.rakuten[:app_id]}&page=#{page_num}"
+    @url += /^978[0-9]{10}/.match?(query) ? "&isbn=#{query}" : "&title=#{query}"
+  end
+
+  def run
+    client = HTTPClient.new
+    request = client.get(@url)
+    JSON.parse(request.body)
+  end
+end

--- a/app/views/api/users/lists/show.json.jbuilder
+++ b/app/views/api/users/lists/show.json.jbuilder
@@ -1,0 +1,16 @@
+json.books do
+  json.array!(@list_details) do |detail|
+    json.list_detail_id detail.id
+    json.book do
+      book = detail.book
+      json.id book.id
+      json.isbn13 book.isbn13
+      json.price book.price
+      json.title book.title
+      json.author book.author
+      json.image book.image
+      json.url book.url
+      json.sales_date book.sales_date
+    end
+  end
+end

--- a/spec/helpers/books_helper_spec.rb
+++ b/spec/helpers/books_helper_spec.rb
@@ -3,41 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe BooksHelper, type: :helper do
-  describe '#registered?' do
-    context 'ListDetailに登録済みの書籍の場合' do
-      it 'trueが返る' do
-        list_detail = create(:list_detail_one)
-        isbn = list_detail.book.isbn13
-        user = list_detail.list.user
-        expect(helper).to be_registered(isbn, user)
-      end
-    end
-
-    context 'ListDetailに登録されていない書籍の場合' do
-      it 'falseが返る' do
-        isbn = create(:perfect_rails).isbn13
-        user = create(:list).user
-        expect(helper).not_to be_registered(isbn, user)
-      end
-    end
-
-    context 'リスト未作成のユーザーの場合' do
-      it 'falseが返る' do
-        isbn = create(:perfect_rails).isbn13
-        user = create(:alice)
-        expect(helper).not_to be_registered(isbn, user)
-      end
-    end
-
-    context '書籍情報が登録されていない場合' do
-      it 'falseが返る' do
-        isbn = build(:perfect_rails).isbn13
-        user = create(:alice)
-        expect(helper).not_to be_registered(isbn, user)
-      end
-    end
-  end
-
   describe '#format_price' do
     context '数値の場合' do
       it '4桁の場合、カンマ区切りに円が付くこと' do


### PR DESCRIPTION
## やったこと
### BooksController
- 楽天にアクセスして書籍情報を取得する処理をクラスに切り出した

### API::BooksController
- 同じクエリを2回発行している部分を1回で済むように修正した
- 新規作成なのか既存のレコードなのかを、`find_or_initialize_by`メソッドを使うようにして、その結果によって処理をわける形に変更した

### API::ListDetailsController
- 存在確認をメソッドに切り出した
- 新規作成なのか既存のレコードなのかを、`find_or_initialize_by`メソッドを使うようにして、その結果によって処理をわける形に変更した

### API::UsersListsController
- jsonでのレスポンス内容をjbuilderで許可したものだけに修正した
- 新規作成なのか既存のレコードなのかを、`find_or_initialize_by`メソッドを使うようにして、その結果によって処理をわける形に変更した