### PR TITLE
エラーハンドリングを追加

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -5,6 +5,10 @@ class BooksController < ApplicationController
     if params[:query].present?
       @query = params[:query]
       @page_num = (params[:page] || 1).to_i
+
+      # APIの仕様上ページ指定は100が上限
+      return redirect_to root_path, alert: 'パラメーターが不正です。' if @page_num.zero? || @page_num.negative? || @page_num > 100
+
       count_per_page = 20
 
       response = RakutenBooksSearcher.new(@query, @page_num, count_per_page).run
@@ -14,8 +18,6 @@ class BooksController < ApplicationController
       @first_num = response['first']
       @last_num = response['last']
       @items = response['Items']
-
-      render :index
     else
       redirect_to root_path, alert: '検索ワードを入力してください。'
     end

--- a/app/models/rakuten_books_searcher.rb
+++ b/app/models/rakuten_books_searcher.rb
@@ -9,7 +9,7 @@ class RakutenBooksSearcher
       affiliateId: Rails.application.credentials.rakuten[:af_id],
       applicationId: Rails.application.credentials.rakuten[:app_id],
       page: page_num,
-      (/^978[0-9]{10}/.match?(query) ? :isbn : :title) => query
+      (/^978[0-9]{10}$/.match?(query) ? :isbn : :title) => query
     }.to_query
     @url = uri.to_s
   end

--- a/spec/models/rakuten_books_searcher_spec.rb
+++ b/spec/models/rakuten_books_searcher_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RakutenBooksSearcher, type: :model do
+  describe '#initialize' do
+    context '13桁のISBNが指定された場合' do
+      it 'クエリストリングにisbnがあること' do
+        searcher = described_class.new('9784774193977', 1, 20)
+        expect(searcher.instance_variable_get(:@url)).to include 'isbn'
+      end
+    end
+
+    context 'isbnではない場合' do
+      it 'クエリストリングにtitleがあること' do
+        searcher = described_class.new('ruby', 1, 20)
+        expect(searcher.instance_variable_get(:@url)).to include 'title'
+      end
+    end
+
+    context 'ISBNが12桁の場合' do
+      it 'クエリストリングにtitleがあること' do
+        searcher = described_class.new('978477419397', 1, 20)
+        expect(searcher.instance_variable_get(:@url)).to include 'title'
+      end
+    end
+
+    context 'ISBNが14桁の場合' do
+      it 'クエリストリングにtitleがあること' do
+        searcher = described_class.new('97847741939771', 1, 20)
+        expect(searcher.instance_variable_get(:@url)).to include 'title'
+      end
+    end
+  end
+
+  describe '#run' do
+    context '正しいISBNの場合' do
+      it 'プロを目指す人のためのRuby入門の結果が返ること' do
+        searcher = described_class.new('9784774193977', 1, 20).run
+        expect(searcher['Items'][0]['Item']['title']).to eq 'プロを目指す人のためのRuby入門'
+      end
+    end
+
+    context '正しいタイトルの場合' do
+      it 'プロを目指す人のためのRuby入門の結果が返ること' do
+        searcher = described_class.new('プロを目指す人のためのRuby入門', 1, 20).run
+        expect(searcher['Items'][0]['Item']['title']).to eq 'プロを目指す人のためのRuby入門'
+      end
+    end
+
+    context '存在しないISBNの場合' do
+      it 'Items配列が空で返ること' do
+        searcher = described_class.new('9780123456789', 1, 20).run
+        expect(searcher['Items']).to eq []
+      end
+    end
+
+    context '存在しないタイトルの場合' do
+      it 'Items配列が空で返ること' do
+        # APIのリクエスト制限に引っかかるのでいったん止める
+        sleep 2
+        searcher = described_class.new('プロを目指さない人のためのRuby入門', 1, 20).run
+        expect(searcher['Items']).to eq []
+      end
+    end
+  end
+end

--- a/spec/system/books_spec.rb
+++ b/spec/system/books_spec.rb
@@ -67,5 +67,23 @@ RSpec.describe 'books', type: :system do
         expect(page).to have_content 'パラメーターが不正です。'
       end
     end
+
+    context 'ISBNが1桁多い場合' do
+      it '該当する書籍がありませんでした。と表示される' do
+        visit_with_auth root_path, :alice
+        fill_in '検索ワード or ISBN', with: '97847741939771'
+        click_button '検索する'
+        expect(page).to have_content '該当する書籍がありませんでした。'
+      end
+    end
+
+    context 'ISBNが1桁少ない場合' do
+      it '該当する書籍がありませんでした。と表示される' do
+        visit_with_auth root_path, :alice
+        fill_in '検索ワード or ISBN', with: '978477419397'
+        click_button '検索する'
+        expect(page).to have_content '該当する書籍がありませんでした。'
+      end
+    end
   end
 end

--- a/spec/system/books_spec.rb
+++ b/spec/system/books_spec.rb
@@ -46,5 +46,26 @@ RSpec.describe 'books', type: :system do
         expect(page).to have_content '検索ワードを入力してください。'
       end
     end
+
+    context '100ページより多いページ数が指定された場合' do
+      it 'パラメーターが不正です。と表示される' do
+        visit_with_auth '/books?page=101&query=ruby', :alice
+        expect(page).to have_content 'パラメーターが不正です。'
+      end
+    end
+
+    context 'ページ数に負の数値が指定された場合' do
+      it 'パラメーターが不正です。と表示される' do
+        visit_with_auth '/books?page=-1&query=ruby', :alice
+        expect(page).to have_content 'パラメーターが不正です。'
+      end
+    end
+
+    context 'ページ数に数値以外が指定された場合' do
+      it 'パラメーターが不正です。と表示される' do
+        visit_with_auth '/books?page=aaa&query=ruby', :alice
+        expect(page).to have_content 'パラメーターが不正です。'
+      end
+    end
   end
 end


### PR DESCRIPTION
ref: #158 #159 

- 書籍検索結果ページ
    - クエリストリングの`page`に負の数や大きすぎる数、文字列が指定された場合の処理を追加
    - ISBNの正規表現が13桁以上を許容する形になっていたので、修正
- それぞれを検証するテストを追加