### PR TITLE
API::ListDetails::IdControllerの書籍がなかった場合のステータスコードを変更

### DIFF
--- a/app/controllers/api/list_details/id_controller.rb
+++ b/app/controllers/api/list_details/id_controller.rb
@@ -6,10 +6,7 @@ class API::ListDetails::IdController < API::BaseController
     list = current_user.list
     list_detail = ListDetail.find_by(list_id: list&.id, book_id: book&.id)
 
-    if list_detail.present?
-      render status: :ok, json: { listDetailId: list_detail.id }
-    else
-      render status: :unprocessable_entity, json: { listDetailId: nil }
-    end
+    id = list_detail.present? ? list_detail.id : nil
+    render status: :ok, json: { listDetailId: id }
   end
 end

--- a/spec/requests/api/list_details/id_spec.rb
+++ b/spec/requests/api/list_details/id_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe 'Api::ListDetails::Id', type: :request do
       end
 
       context '登録済みでない場合' do
-        it '422が返ること' do
+        it '200が返ること' do
           sign_in user
           get api_list_details_id_index_path({ isbn: other_book.isbn13 })
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:ok)
         end
 
         it 'リスト詳細IDはnilであること' do


### PR DESCRIPTION
ref: #161 

これまでは`422`を返していたがこれは不適切なので、`200`に変更。