### PR TITLE
AmazonCrawlerの金額取得方法を変更

### DIFF
--- a/lib/crawler/amazon_crawler.rb
+++ b/lib/crawler/amazon_crawler.rb
@@ -29,7 +29,7 @@ class AmazonCrawler < Crawler
       kindle_price = ver_list_dom[0].text.split("\n")[1].delete('￥,').to_i
       data << kindle_price
 
-      paper_price = ver_list_dom[1].text.split("\n")[1].delete('￥,').to_i
+      paper_price = ver_list_dom[-1].text.split("\n")[1].delete('￥,').to_i
       data << paper_price
 
       ver_list_dom[0].click

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -50,4 +50,14 @@ FactoryBot.define do
     isbn13 { '9784839962227' }
     price { 3828 }
   end
+
+  factory :dokugaku, class: 'Book' do
+    title { '独学大全' }
+    author { '読書猿' }
+    image { 'https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8536/9784478108536.jpg?_ex=120x120' }
+    url { 'https://hb.afl.rakuten.co.jp/hgc/g00q0727.m0lf90b6.g00q0727.m0lfa419/?pc=https%3A%2F%2Fbooks.rakuten.co.jp%2Frb%2F15628625%2F' }
+    sales_date { '2018年10月19日頃' }
+    isbn13 { '9784478108536' }
+    price { 3080 }
+  end
 end

--- a/spec/system/amazon_crawler_spec.rb
+++ b/spec/system/amazon_crawler_spec.rb
@@ -7,12 +7,18 @@ RSpec.describe 'AmazonCrawler', type: :system do
   describe 'run' do
     let(:crawler) { AmazonCrawler.new }
     let(:book) { build(:perfect_rails) }
+    let(:dokugaku) { build(:dokugaku) }
 
     it '金額は数値、ASINは10桁の文字列が返ってくること' do
       crawler.run(book.isbn13)
       expect(crawler.kindle_price).to be_integer
       expect(crawler.paper_price).to be_integer
       expect(crawler.asin.size).to eq 10
+    end
+
+    it 'audible版がある書籍でも0円にならないこと' do
+      crawler.run(dokugaku.isbn13)
+      expect(crawler.paper_price).not_to eq 0
     end
   end
 end


### PR DESCRIPTION
ref: #162 

audible版がある書籍だと、`ver_list_dom[1]`はaudible版の金額になってしまう。
`ver_list_dom[-1]`として、audible版があってもなくても紙書籍の金額を取得できるように修正した。