### PR TITLE
Bookモデルの不要なバリデーションを削除

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -7,8 +7,6 @@ class Book < ApplicationRecord
   validates :isbn13, presence: true, length: { is: 13 }
   validates :price, presence: true, numericality: { only_integer: true }
   validates :title, presence: true
-  validates :author, presence: true
   validates :image, presence: true
   validates :url, presence: true
-  validates :sales_date, presence: true
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -66,10 +66,9 @@ RSpec.describe Book, type: :model do
 
   describe 'author' do
     context '空の場合' do
-      it '登録失敗' do
+      it '登録成功' do
         book = build(:cherry, author: '')
-        book.valid?
-        expect(book.errors[:author]).to include('を入力してください')
+        expect(book).to be_valid
       end
     end
   end
@@ -96,10 +95,9 @@ RSpec.describe Book, type: :model do
 
   describe 'sales_date' do
     context '空の場合' do
-      it '登録失敗' do
+      it '登録成功' do
         book = build(:cherry, sales_date: '')
-        book.valid?
-        expect(book.errors[:sales_date]).to include('を入力してください')
+        expect(book).to be_valid
       end
     end
   end


### PR DESCRIPTION
ref: #160 

`author`がAPIのレスポンスにない場合があり、これが原因でリストに登録できない問題が発生していた。
`author`は必ずしも必要な情報ではないので`presence`のバリデーションを削除した。
同じ理由で、`sales_date`の`presence`も削除した。